### PR TITLE
Removes "prettier/react" from eslint config

### DIFF
--- a/eslint-prettier-config.sh
+++ b/eslint-prettier-config.sh
@@ -123,8 +123,7 @@ else
   echo ${config_opening}'
   "extends": [
     "airbnb",
-    "plugin:prettier/recommended",
-    "prettier/react"
+    "plugin:prettier/recommended"
   ],
   "env": {
     "browser": true,


### PR DESCRIPTION
Eslint config (since v 8) requires to use only "plugin:prettier/recommended" in the "extends" property, instead of "plugin:prettier/recommended", "prettier/react".

The configuration file with the script (as it is now) is created with:

```js
"extends": [
    "airbnb",
    "plugin:prettier/recommended",
    "prettier/react"
  ]
```

And it will break the compilation process. It must be changed to:

```js
"extends": [
    "airbnb",
    "plugin:prettier/recommended",
  ]
```

[Here you can find official info](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21).